### PR TITLE
*args,*kwargs functionality

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -9,7 +9,10 @@ load-plugins=pylint_django
 # Disable the following checks (example list):
 disable= unused-argument,
          line-too-long,
-         redefined-outer-name
+         redefined-outer-name,
+         unused-variable,
+         missing-module-docstring,
+         missing-function-docstring
 
 [REPORTS]
 # Set the output format. Available formats: text, parseable, colorized, json, msvs (visual studio) and html

--- a/app/commands/__init__.py
+++ b/app/commands/__init__.py
@@ -2,8 +2,7 @@ from abc import ABC, abstractmethod
 
 class Command(ABC):
     @abstractmethod
-    def execute(self):
-        pass
+    def execute(self, *args, **kwargs):pass
 
 class CommandHandler:
     def __init__(self):
@@ -12,9 +11,9 @@ class CommandHandler:
     def register_command(self, command_name: str, command: Command):
         self.commands[command_name] = command
 
-    def execute_command(self, command_name: str):
+    def execute_command(self, command_name: str, *args, **kwargs):
         if command_name in self.commands:
-            self.commands[command_name].execute()
+            # Passing additional arguments to the command's execute method
+            self.commands[command_name].execute(*args, **kwargs)
         else:
             print(f"No such command: {command_name}")
-

--- a/app/commands/exit/__init__.py
+++ b/app/commands/exit/__init__.py
@@ -3,5 +3,7 @@ from app.commands import Command
 
 
 class ExitCommand(Command):
-    def execute(self):
-        sys.exit("Exiting...")
+    def execute(self, *args, **kwargs):
+        exit_message = args[0] if args else "Exiting..."
+        exit_code = kwargs.get('exit_code', 0)
+        sys.exit(f"{exit_message}\nExit Code: {exit_code}")

--- a/app/commands/goodbye/__init__.py
+++ b/app/commands/goodbye/__init__.py
@@ -1,6 +1,6 @@
 from app.commands import Command
 
-
 class GoodbyeCommand(Command):
-    def execute(self):
-        print("Goodbye")
+    def execute(self, *args, **kwargs):
+        farewell_message = args[0] if args else "Goodbye"
+        print(f"{farewell_message}")

--- a/app/commands/greet/__init__.py
+++ b/app/commands/greet/__init__.py
@@ -2,5 +2,7 @@ from app.commands import Command
 
 
 class GreetCommand(Command):
-    def execute(self):
-        print("Hello, World!")
+    def execute(self, *args, **kwargs):
+        name = args[0] if args else "World"
+        greeting = kwargs.get('greeting', 'Hello')
+        print(f"{greeting}, {name}!")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,8 +12,6 @@ def test_app_start_exit_command(capfd, monkeypatch):
 
 
 
-import pytest
-
 def test_app_start_unknown_command(capfd, monkeypatch):
     """Test how the REPL handles an unknown command before exiting."""
     # Simulate user entering an unknown command followed by 'exit'
@@ -21,13 +19,10 @@ def test_app_start_unknown_command(capfd, monkeypatch):
     monkeypatch.setattr('builtins.input', lambda _: next(inputs))
 
     app = App()
-    
     with pytest.raises(SystemExit) as excinfo:
         app.start()
-    
     # Optionally, check for specific exit code or message
     # assert excinfo.value.code == expected_exit_code
-    
     # Verify that the unknown command was handled as expected
     captured = capfd.readouterr()
     assert "No such command: unknown_command" in captured.out

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5,18 +5,29 @@ from app.commands.greet import GreetCommand
 
 def test_greet_command(capfd):
     command = GreetCommand()
+
+    # Test without args and kwargs
     command.execute()
     out, err = capfd.readouterr()
     assert out == "Hello, World!\n", "The GreetCommand should print 'Hello, World!'"
 
+    # Test with args and kwargs
+    command.execute("Alice", greeting="Hi")
+    out, err = capfd.readouterr()
+    assert out == "Hi, Alice!\n", "The GreetCommand should print 'Hi, Alice!'"
+
 def test_goodbye_command(capfd):
     command = GoodbyeCommand()
+
+    # Test without args and kwargs
     command.execute()
     out, err = capfd.readouterr()
-    assert out == "Goodbye\n", "The GreetCommand should print 'Hello, World!'"
+    assert out == "Goodbye\n", "The GoodbyeCommand should print 'Goodbye'"
 
-
-import pytest
+    # Test with args and kwargs
+    command.execute("See you", farewell="Adios")
+    out, err = capfd.readouterr()
+    assert out == "See you\n", "The GoodbyeCommand should print 'See you'"
 
 def test_app_greet_command(capfd, monkeypatch):
     """Test that the REPL correctly handles the 'greet' command."""
@@ -26,8 +37,5 @@ def test_app_greet_command(capfd, monkeypatch):
 
     app = App()
     with pytest.raises(SystemExit) as e:
-        app.start()  # Assuming App.start() is now a static method based on previous discussions
-    
-    assert str(e.value) == "Exiting...", "The app did not exit as expected"
-
-
+        app.start()
+    assert str(e.value) == "Exiting...\nExit Code: 0", "The app did not exit as expected"


### PR DESCRIPTION
Extended the functionality of the command class to accept user input using Args or Kwargs. updated the test cases to cover the *args and **kwargs and obtained a 100% test coverage 

![image](https://github.com/kaw393939/calc_design_patterns/assets/64483756/92261e4f-6870-4e8f-968b-f56e3d2d4178)
